### PR TITLE
VSW-380: Change coredump region to just kernel ram

### DIFF
--- a/subsys/debug/coredump/coredump_memory_regions.c
+++ b/subsys/debug/coredump/coredump_memory_regions.c
@@ -16,7 +16,7 @@
 
 #ifdef CONFIG_DEBUG_COREDUMP_MEMORY_DUMP_LINKER_RAM
 struct z_coredump_memory_region_t __weak z_coredump_memory_regions[] = {
-	{(uintptr_t)&_image_ram_start, (uintptr_t)&_image_ram_end},
+	{(uintptr_t)&__kernel_ram_start, (uintptr_t)&__kernel_ram_end},
 	{0, 0} /* End of list */
 };
 #endif


### PR DESCRIPTION
This excludes redundant information such as text and and ro area

See https://github.com/pensando/ainic-rtos/pull/114 for more information about coredump size improvements.