### PR TITLE
Enable PMP entries for Vulcano AINIC

### DIFF
--- a/arch/riscv/Kconfig
+++ b/arch/riscv/Kconfig
@@ -319,6 +319,11 @@ config PMP_GRANULARITY
 	  (ie 4, 8, 16, ...), but if neither TOR mode nor NA4 mode is
 	  supported, the minimum granularity is 8.
 
+config CUSTOM_PMP_ENTRIES
+	bool "Select custom PMP entries"
+	help
+	  This option provides custom PMP entries to be programmed
+
 endif #RISCV_PMP
 
 config PMP_STACK_GUARD

--- a/arch/riscv/include/pmp.h
+++ b/arch/riscv/include/pmp.h
@@ -7,6 +7,19 @@
 #ifndef PMP_H_
 #define PMP_H_
 
+#ifdef CONFIG_CUSTOM_PMP_ENTRIES
+struct custom_pmp_entries {
+        unsigned long addr;
+        unsigned long size;
+        uint8_t flags;
+};
+
+struct custom_n_pmp_entries {
+        unsigned int nentries;
+        struct custom_pmp_entries *entries;
+};
+#endif
+
 void z_riscv_pmp_init(void);
 void z_riscv_pmp_stackguard_prepare(struct k_thread *thread);
 void z_riscv_pmp_stackguard_enable(struct k_thread *thread);


### PR DESCRIPTION
1. Enable access to LLC memory range - 32MB
2. Disable access to rest of the memory

Following UT has been done:

Access UART register space

```
uart:~$ devmem 0xf0000 32

Using data width 32

Read value 0x7f
```

Null address access (config enabled for NULL pointer PMP entry)

```
uart:~$ devmem 0x0 32

Using data width 32l[00:00:00.009,938] <inf> libpciemgrd: reboot_on_hostdn: 0

[00:00:00.009,938] <inf> libpciemgrd: ---------------- config ----------------

[00:00:00.010,023] <inf> pciemgr: memopen: init magic 706d656d/706d656d version 1/1

[00:00:00.010,044] <inf> libpciemgrd: drv_open: using user

[00:00:00.010,046] <inf> pciemgrd: pciemgrd ready

[00:00:00.015,485] <err> os: 

[00:00:00.015,485] <err> os:  mcause: 5, Load access fault

[00:00:00.015,485] <err> os:   mtval: 0
```

Access LLC base memory and access should work:

```
uart:~$ devmem 0x8100000000 32

Using data width 32

Read value 0x0

uart:~$ devmem 0x8100000000 32 0x11

Using data width 32

Writing value 0x11

uart:~$ devmem 0x8100000000 32

Using data width 32

Read value 0x11

```

Access memory outside the LLC/allowed peripheral address range

```
uart:~$ devmem 0x8102000200 32

Using data width 3i[00:00:00.010,372] <inf> libpciemgrd: reboot_on_hostdn: 0

[00:00:00.010,372] <inf> libpciemgrd: ---------------- config ----------------

[00:00:00.010,456] <inf> pciemgr: memopen: init magic 706d656d/706d656d version 1/1

[00:00:00.010,478] <inf> libpciemgrd: drv_open: using user

[00:00:00.010,479] <inf> pciemgrd: pciemgrd ready

[00:00:00.016,940] <err> os: 

[00:00:00.016,940] <err> os:  mcause: 5, Load access fault

[00:00:00.016,940] <err> os:   mtval: 8102000200

[00:00:00.016,940] <err> os:      a0: 0000000000000000    t0: 0000008101a52070

[00:00:00.016,942] <err> os:      a1: ffffffffffffffff    t1: 0000008101a1b7c3


```


Access read only text memory and check write access:

```
uart:~$ devmem 0x810181c000 32

Using data width 32

Read value 0x236197

uart:~$ devmem 0x810181c000 32 0x11

Using data width 32

Writing value 0x11

000000000000 0x00[00:00:00.009,570] <err> os: 

[00:00:00.009,572] <err> os:  mcause: 7, Store/AMO access fault

[00:00:00.009,572] <err> os:   mtval: 810181c000

[00:00:00.009,572] <err> os:      a0: 0000000000000000    t0: 0000008101a52070

```