### PR TITLE
coredump: use shared buffer for callback devices

### DIFF
--- a/drivers/coredump/coredump_impl.c
+++ b/drivers/coredump/coredump_impl.c
@@ -145,7 +145,7 @@ static const struct coredump_driver_api coredump_api = {
 			"Allow exactly one entry (address and size) in memory_regions");     \
 		BUILD_ASSERT(DT_INST_PROP_BY_IDX(n, memory_regions, 0) == 0,             \
 			"Verify address is set to 0");                                       \
-		static uint8_t coredump_bytes_##n[DT_INST_PROP_BY_IDX(n, memory_regions, 1)] \
+		static uint8_t coredump_bytes[DT_INST_PROP_BY_IDX(n, memory_regions, 1)] \
 			__aligned(4);                                                        \
 	), ())                                                                       \
 	static struct coredump_data coredump_data_##n;                               \
@@ -158,7 +158,7 @@ static const struct coredump_driver_api coredump_api = {
 			(                                                                    \
 			/* Callback type device has one entry in memory_regions array */     \
 			.memory_regions = {                                                  \
-				(size_t)&coredump_bytes_##n[0],                                  \
+				(size_t)&coredump_bytes[0],                                      \
 				DT_INST_PROP_BY_IDX(n, memory_regions, 1),                       \
 			},                                                                   \
 			),                                                                   \

--- a/drivers/coredump/coredump_impl.c
+++ b/drivers/coredump/coredump_impl.c
@@ -9,9 +9,20 @@
 
 #define DT_DRV_COMPAT zephyr_coredump
 
+/**
+ * Size of the shared buffer for callback-type coredump devices.
+ * This buffer is reused across all callback devices to reduce memory usage.
+ * Callbacks that need to dump more data than this size will be invoked
+ * multiple times with increasing offsets.
+ */
+#ifndef CONFIG_COREDUMP_DEVICE_SHARED_BUFFER_SIZE
+#define CONFIG_COREDUMP_DEVICE_SHARED_BUFFER_SIZE (64 * 1024)
+#endif
+
 enum COREDUMP_TYPE {
 	COREDUMP_TYPE_MEMCPY = 0,
 	COREDUMP_TYPE_CALLBACK = 1,
+	COREDUMP_TYPE_CALLBACK_POOLED_BUFFERED = 2,
 };
 
 struct coredump_config {
@@ -31,7 +42,17 @@ struct coredump_data {
 
 	/* Callback to be invoked at time of dump */
 	coredump_dump_callback_t dump_callback;
+
+	/* Callback for pooled-buffered type with chunking support */
+	coredump_dump_callback_pooled_t dump_callback_pooled;
 };
+
+/*
+ * Single shared buffer for all callback-type coredump devices.
+ * This significantly reduces memory usage compared to allocating
+ * separate buffers per device.
+ */
+static uint8_t coredump_shared_buffer[CONFIG_COREDUMP_DEVICE_SHARED_BUFFER_SIZE] __aligned(4);
 
 static void coredump_impl_dump(const struct device *dev)
 {
@@ -46,6 +67,29 @@ static void coredump_impl_dump(const struct device *dev)
 			/* Invoke callback to allow consumer to fill array with desired data */
 			data->dump_callback(start_address, size);
 			coredump_memory_dump(start_address, start_address + size);
+		}
+	} else if (config->type == COREDUMP_TYPE_CALLBACK_POOLED_BUFFERED) {
+		/* Pooled-buffered callback: Uses shared buffer with chunking */
+		if (data->dump_callback_pooled) {
+			uintptr_t buffer_addr = (uintptr_t)coredump_shared_buffer;
+			size_t buffer_size = sizeof(coredump_shared_buffer);
+			size_t offset = 0;
+			size_t bytes_written;
+
+			/*
+			 * Invoke callback repeatedly until it returns 0.
+			 * Each iteration:
+			 *   1. Callback fills shared buffer with data starting at 'offset'
+			 *   2. Dump that chunk to the backend
+			 *   3. Increment offset by bytes written
+			 */
+			do {
+				bytes_written = data->dump_callback_pooled(buffer_addr, buffer_size, offset);
+				if (bytes_written > 0) {
+					coredump_memory_dump(buffer_addr, buffer_addr + bytes_written);
+					offset += bytes_written;
+				}
+			} while (bytes_written > 0);
 		}
 	} else { /* COREDUMP_TYPE_MEMCPY */
 		/*
@@ -118,6 +162,20 @@ static bool coredump_impl_register_callback(const struct device *dev,
 	return true;
 }
 
+static bool coredump_impl_register_callback_pooled(const struct device *dev,
+	coredump_dump_callback_pooled_t callback)
+{
+	const struct coredump_config *config = dev->config;
+	struct coredump_data *data = dev->data;
+
+	if (config->type != COREDUMP_TYPE_CALLBACK_POOLED_BUFFERED) {
+		return false;
+	}
+
+	data->dump_callback_pooled = callback;
+	return true;
+}
+
 static int coredump_init(const struct device *dev)
 {
 	struct coredump_data *data = dev->data;
@@ -131,6 +189,7 @@ static const struct coredump_driver_api coredump_api = {
 	.register_memory = coredump_impl_register_memory,
 	.unregister_memory = coredump_impl_unregister_memory,
 	.register_callback = coredump_impl_register_callback,
+	.register_callback_pooled = coredump_impl_register_callback_pooled,
 };
 
 #define INIT_REGION(node_id, prop, idx) DT_PROP_BY_IDX(node_id, prop, idx),

--- a/dts/bindings/coredump/zephyr,coredump.yaml
+++ b/dts/bindings/coredump/zephyr,coredump.yaml
@@ -30,3 +30,4 @@ properties:
     enum:
       - "COREDUMP_TYPE_MEMCPY"
       - "COREDUMP_TYPE_CALLBACK"
+      - "COREDUMP_TYPE_CALLBACK_POOLED_BUFFERED"

--- a/include/zephyr/drivers/coredump.h
+++ b/include/zephyr/drivers/coredump.h
@@ -55,6 +55,26 @@ struct coredump_mem_region_node {
 typedef void (*coredump_dump_callback_t)(uintptr_t dump_area, size_t dump_area_size);
 
 /**
+ * @brief Pooled-buffered callback that occurs at dump time with chunking support.
+ * Data copied into dump_area will be included in the dump that is generated.
+ *
+ * This callback supports chunked dumping to reduce memory usage. A single
+ * shared buffer is provided, and the callback can be invoked multiple times
+ * to dump data larger than the buffer size.
+ *
+ * @param dump_area      Pointer to area to copy data into for inclusion in dump
+ * @param dump_area_size Size of available memory at dump_area
+ * @param offset         Byte offset into the logical dump data. First call is 0,
+ *                       subsequent calls provide the cumulative bytes written so far.
+ *
+ * @return Number of bytes written to dump_area. Return 0 to indicate dumping is
+ *         complete. The coredump subsystem will keep calling this callback with
+ *         updated offsets until 0 is returned.
+ */
+typedef size_t (*coredump_dump_callback_pooled_t)(uintptr_t dump_area, size_t dump_area_size,
+	size_t offset);
+
+/**
  * @cond INTERNAL_HIDDEN
  *
  * For internal use only, skip these in public documentation.
@@ -88,6 +108,13 @@ typedef bool (*coredump_device_register_callback_t)(const struct device *dev,
 	coredump_dump_callback_t callback);
 
 /*
+ * Type definition of coredump API function for registering a pooled-buffered
+ * dump callback
+ */
+typedef bool (*coredump_device_register_callback_pooled_t)(const struct device *dev,
+	coredump_dump_callback_pooled_t callback);
+
+/*
  * API which a coredump pseudo-device driver should expose
  */
 __subsystem struct coredump_driver_api {
@@ -95,6 +122,7 @@ __subsystem struct coredump_driver_api {
 	coredump_device_register_memory_t   register_memory;
 	coredump_device_unregister_memory_t unregister_memory;
 	coredump_device_register_callback_t register_callback;
+	coredump_device_register_callback_pooled_t register_callback_pooled;
 };
 
 /**
@@ -155,6 +183,28 @@ static inline bool coredump_device_register_callback(const struct device *dev,
 		(const struct coredump_driver_api *)dev->api;
 
 	return api->register_callback(dev, callback);
+}
+
+/**
+ * @brief Register a pooled-buffered callback to be invoked at dump time
+ *
+ * Use this for COREDUMP_TYPE_CALLBACK_POOLED_BUFFERED devices. The callback
+ * will be invoked multiple times with increasing offsets until it returns 0,
+ * allowing dumping of data larger than the shared buffer size.
+ *
+ * @param dev      Pointer to the device structure for the driver instance.
+ * @param callback Callback to be invoked at dump time
+ *
+ * @return true if registration succeeded
+ * @return false if registration failed
+ */
+static inline bool coredump_device_register_callback_pooled(const struct device *dev,
+	coredump_dump_callback_pooled_t callback)
+{
+	const struct coredump_driver_api *api =
+		(const struct coredump_driver_api *)dev->api;
+
+	return api->register_callback_pooled(dev, callback);
 }
 
 /**


### PR DESCRIPTION
Replace per-device buffer allocation with a single shared 64KiB buffer for callback-type coredump devices.

 - Add `CONFIG_COREDUMP_DEVICE_SHARED_BUFFER_SIZE` (default 64KiB)
 - Update callback signature to support chunked dumping:
       `size_t callback(uintptr_t dump_area, size_t size, size_t offset)`

https://github.com/pensando/ainic-rtos/pull/774 needs the patch in this PR.