### PR TITLE
AI-5609: guard cache/net Kconfig symbols against -Wundef

### DIFF
--- a/include/zephyr/cache.h
+++ b/include/zephyr/cache.h
@@ -408,7 +408,7 @@ static ALWAYS_INLINE size_t sys_cache_data_line_size_get(void)
 {
 #ifdef CONFIG_DCACHE_LINE_SIZE_DETECT
 	return cache_data_line_size_get();
-#elif (CONFIG_DCACHE_LINE_SIZE != 0)
+#elif defined(CONFIG_DCACHE_LINE_SIZE) && (CONFIG_DCACHE_LINE_SIZE != 0)
 	return CONFIG_DCACHE_LINE_SIZE;
 #else
 	return DT_PROP_OR(_CPU, d_cache_line_size, 0);
@@ -435,7 +435,7 @@ static ALWAYS_INLINE size_t sys_cache_instr_line_size_get(void)
 {
 #ifdef CONFIG_ICACHE_LINE_SIZE_DETECT
 	return cache_instr_line_size_get();
-#elif (CONFIG_ICACHE_LINE_SIZE != 0)
+#elif defined(CONFIG_ICACHE_LINE_SIZE) && (CONFIG_ICACHE_LINE_SIZE != 0)
 	return CONFIG_ICACHE_LINE_SIZE;
 #else
 	return DT_PROP_OR(_CPU, i_cache_line_size, 0);

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -1229,7 +1229,7 @@ int net_if_set_link_addr_locked(struct net_if *iface,
 				uint8_t *addr, uint8_t len,
 				enum net_link_type type);
 
-#if CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG
+#if defined(CONFIG_NET_IF_LOG_LEVEL) && (CONFIG_NET_IF_LOG_LEVEL >= LOG_LEVEL_DBG)
 extern int net_if_addr_unref_debug(struct net_if *iface,
 				   sa_family_t family,
 				   const void *addr,

--- a/include/zephyr/net_buf.h
+++ b/include/zephyr/net_buf.h
@@ -30,7 +30,7 @@ extern "C" {
  */
 
 /* Alignment needed for various parts of the buffer definition */
-#if CONFIG_NET_BUF_ALIGNMENT == 0
+#if (!defined(CONFIG_NET_BUF_ALIGNMENT) || (CONFIG_NET_BUF_ALIGNMENT == 0))
 #define __net_buf_align __aligned(sizeof(void *))
 #else
 #define __net_buf_align __aligned(CONFIG_NET_BUF_ALIGNMENT)


### PR DESCRIPTION
Enabling `-Wundef` for `vulcano` builds surfaced build errors on cache/net `Kconfig` symbols.
headers (like cache.h) reference the symbols unconditionally, assuming owning subsystem
(`CACHE_MANAGEMENT` / `NETWORKING`) is selected but `vulcano` builds don't select it,
 so the symbols are never defined.

- guard `CONFIG_DCACHE_LINE_SIZE`/`CONFIG_ICACHE_LINE_SIZE` with `defined(...)`

- guards `CONFIG_NET_IF_LOG_LEVEL` with `defined(...)`

- guard `CONFIG_NET_BUF_ALIGNMENT` to prevent undefined errors 
  and prevent undefined macro reaching #else